### PR TITLE
Fixed code execution on create-git

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const shell = require('shelljs')
 const fs = require('fs-extra')
 const parseList = require('safe-parse-list')
 const parseIgnore = require('./lib/ignore')
+const shellescape = require('shell-escape')
 
 module.exports = create({
   commandDescription: 'Initalize a git repo',
@@ -129,6 +130,12 @@ module.exports = create({
     ignoreRules.concat(opts.additionalRules)
   }
 
+  // Escape Bad Shell Arguments
+  let escapeShell = function(cmd) {
+    let arg = cmd.split(" ")
+    return shellescape(arg)
+  }
+
   // Create directory and init git
   await fs.ensureDir(path.join(opts.directory))
   await shell.exec('git init', {
@@ -137,7 +144,7 @@ module.exports = create({
   })
 
   if (opts.remoteOrigin) {
-    await shell.exec(`git remote add origin ${opts.remoteOrigin}`, {
+    await shell.exec(escapeShell(`git remote add origin ${opts.remoteOrigin}`), {
       cwd: opts.directory,
       silent: opts.silent
     })
@@ -151,7 +158,7 @@ module.exports = create({
       cwd: opts.directory,
       silent: opts.silent
     })
-    await shell.exec(`git commit -am "${opts.initialCommitMessage}"`, {
+    await shell.exec(escapeShell(`git commit -am "${opts.initialCommitMessage}"`), {
       cwd: opts.directory,
       silent: opts.silent
     })

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "inquirer": "^6.2.0",
     "parse-gitignore": "^1.0.1",
     "safe-parse-list": "0.0.1",
-    "shelljs": "^0.8.2"
+    "shelljs": "^0.8.2",
+    "shell-escape": "^0.2.0"
   },
   "devDependencies": {
     "mocha": "^6.2.2",


### PR DESCRIPTION
### 📊 Metadata *

Code execution vulnerabilty 
#### Bounty URL:  https://www.huntr.dev/app/bounties/open/1-npm-create-git

### ⚙️ Description *

Fixed the code execution by escaping the shell argument passed to `shelljs` using the [shell-escape](https://www.npmjs.com/package/shell-escape) library. 

### 💻 Technical Description *

shell-escape is used to escape and stringify an array of arguments to be executed on the shell. There were multiple instances of `shell.exec()` calls on index.js, so an `escapeShell()` function is used as a wrapper to exec calls. This mitigates the code execution issue.

### 🐛 Proof of Concept (PoC) *

Create a project with the vulnerable package and run the following snippet, a file named `HACKED` should appear in the current working directory, demonstrating the code execution issue.

```javascript
const createGit = require('create-git')
 
createGit({
    ignoreExisting: true,
    initialCommitMessage: 'test',
    remoteOrigin: 'http://evil.com ; touch HACKED #',
    ignoreTemplates: ['Node.gitignore']
});
```

![before](https://user-images.githubusercontent.com/16708391/88407834-4fa0ba00-cdf0-11ea-8d2f-9bb78f3ec385.PNG)

### 🔥 Proof of Fix (PoF) *

After applying the fix, the `escape-shell` module properly sanitizes the user-supplied information before passing into the `shell.exec()`.

![after](https://user-images.githubusercontent.com/16708391/88409609-cc349800-cdf2-11ea-87ad-45de124b356c.PNG)

After running the POC code again, there was no file created. Hence the code exec issue is fixed.

*this is the second PR, commits are changed according to https://github.com/418sec/create-git/pull/1#issuecomment-664539436*